### PR TITLE
remove `-D` flag from npm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ JSX code.
 ### Installation
 
 ```javascript
-npm i -D react-country-region-selector
+npm i react-country-region-selector
 ```
 
 <a name="features"></a>


### PR DESCRIPTION
As I understand it, the `-D` flag will add the module to `devDepencencies`, I'm pretty sure it should normally go into `dependencies` to be available in the browser, so no flag needed.

Please correct me if I'm wrong and drop the PR if not applicable 😉