### PR TITLE
Use React.forwardRef for compatibility with react-hook-form

### DIFF
--- a/src/CountryDropdown.js
+++ b/src/CountryDropdown.js
@@ -4,9 +4,9 @@ import CountryRegionData from '../node_modules/country-region-data/data.json';
 import C from './constants';
 import * as helpers from './helpers';
 
-export default React.forwardRef((props, ref) => <CountryDropdown innerRef={ref} {...props} />)
+export const CountryDropdownWithRef = React.forwardRef((props, ref) => <CountryDropdown innerRef={ref} {...props} />)
 
-class CountryDropdown extends Component {
+export default class CountryDropdown extends Component {
 
 	constructor (props) {
 		super(props);

--- a/src/CountryDropdown.js
+++ b/src/CountryDropdown.js
@@ -4,7 +4,9 @@ import CountryRegionData from '../node_modules/country-region-data/data.json';
 import C from './constants';
 import * as helpers from './helpers';
 
-export default class CountryDropdown extends Component {
+export default React.forwardRef((props, ref) => <CountryDropdown innerRef={ref} {...props} />)
+
+class CountryDropdown extends Component {
 
 	constructor (props) {
 		super(props);
@@ -55,7 +57,7 @@ export default class CountryDropdown extends Component {
 		}
 
 		return (
-			<select {...attrs}>
+			<select ref={this.props.innerRef} {...attrs}>
 				{this.getDefaultOption()}
 				{this.getCountries()}
 			</select>

--- a/src/RegionDropdown.js
+++ b/src/RegionDropdown.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import CountryRegionData from '../node_modules/country-region-data/data.json';
 import C from './constants';
 
-export default class RegionDropdown extends PureComponent {
+export default React.forwardRef((props, ref) => <RegionDropdown innerRef={ref} {...props} />)
+
+class RegionDropdown extends PureComponent {
 	constructor (props) {
 		super(props);
 		this.state = {
@@ -124,7 +126,7 @@ export default class RegionDropdown extends PureComponent {
 		}
 
 		return (
-			<select {...attrs}>
+			<select ref={this.props.innerRef} {...attrs}>
 				{this.getDefaultOption()}
 				{this.getRegionList()}
 			</select>

--- a/src/RegionDropdown.js
+++ b/src/RegionDropdown.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import CountryRegionData from '../node_modules/country-region-data/data.json';
 import C from './constants';
 
-export default React.forwardRef((props, ref) => <RegionDropdown innerRef={ref} {...props} />)
+export const RegionDropdownWithRef = React.forwardRef((props, ref) => <RegionDropdown innerRef={ref} {...props} />)
 
-class RegionDropdown extends PureComponent {
+export default class RegionDropdown extends PureComponent {
 	constructor (props) {
 		super(props);
 		this.state = {


### PR DESCRIPTION
This is a quick and dirty PR to get started #83 as I wanted support for passing a ref with react-hook-form.

We could change the default export to use just the ref like so:

```javascript
export default React.forwardRef((props, ref) => <CountryDropdown innerRef={ref} {...props} />)
```

But the tests will fail because it needs to dive into the component once like this:

```javascript
it('confirm default label is "Select Country"', () => {
const wrapper = shallow(
	<CountryDropdown />
);

expect(wrapper.find('CountryDropdown').dive().find('select').childAt(0).text()).toBe('Select Country');
});
```

And so I just added an alternate export `CountryDropdownWithRef` and `RegionDropdownWithRef`

I'm open to doing the above and changing all the tests or moving forward with this. And I did test it with react-hook-form though not extensively but it seemed to work for the most part.

Let me know what ya'll think.