### PR TITLE
Feat: Fix type mismatch in onBlur

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ export interface CountryDropdownProps<T = Element> {
   value: string;
 
   /**
-   * that gets called when the user selects a country. Use
+   * Callback that gets called when the user selects a country. Use
    * this to store the value in whatever store you're
    * using (or just the parent component state).
    * 
@@ -31,9 +31,11 @@ export interface CountryDropdownProps<T = Element> {
   /**
    * Callback that gets called when the user blurs off the country field.
    *
+   * The original event is also provided optionally.
+   *
    * Default value: undefined
    */
-  onBlur?: (val: string) => void;
+  onBlur?: (val: string, e?: React.ChangeEvent<T>) => void;
 
   /**
    * The name attribute of the generated select box.
@@ -155,9 +157,11 @@ export interface RegionDropdownProps<T = Element> {
   /**
    * Callback that gets called when the user blurs off the region field.
    *
+   * The original event is also provided optionally.
+   *
    * Default value: undefined
    */
-  onBlur?: string;
+  onBlur?: (val: string, e?: React.ChangeEvent<T>) => void;
 
   /**
    * The name attribute of the generated select box.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-country-region-selector",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1828,7 +1828,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -2678,7 +2679,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         },
         "micromatch": {
@@ -3167,10 +3169,13 @@
       }
     },
     "country-region-data": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/country-region-data/-/country-region-data-1.5.1.tgz",
-      "integrity": "sha512-fRiXQ21MCZy678IJL/SSHeNMG/WR7vAY1B25D4dCQdc0o31nCytNaL8LJs2cscegtI265JvZxRc5QI4nugpu8Q==",
-      "dev": true
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/country-region-data/-/country-region-data-1.6.0.tgz",
+      "integrity": "sha512-MPsZo6VlezyxuWoWg5eL6f657qvEHbjkiak4jG1xejmvRgXBA/j+PDvxWFqB4q/clVAYE0Li4hKv9h1ymJafyQ==",
+      "dev": true,
+      "requires": {
+        "package-lock.json": "^1.0.0"
+      }
     },
     "create-ecdh": {
       "version": "4.0.3",
@@ -8959,6 +8964,12 @@
         "semver": "^5.1.0"
       }
     },
+    "package-lock.json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-lock.json/-/package-lock.json-1.0.0.tgz",
+      "integrity": "sha512-+yEXtNdlCs5N0Zy/9uvkifgf/RqnGu0WqP4j9Wu1Us4YReFe1YNBh2Krmf8B1xGxjpYnta63K55QP8bkafnOzA==",
+      "dev": true
+    },
     "pako": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
@@ -12890,7 +12901,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/src/CountryDropdown.js
+++ b/src/CountryDropdown.js
@@ -44,7 +44,7 @@ export default class CountryDropdown extends Component {
 			name,
 			value,
 			onChange: (e) => onChange(e.target.value, e),
-			onBlur: (e) => onBlur(e),
+			onBlur: (e) => onBlur(e.target.value, e),
 			disabled
 		};
 		if (id) {

--- a/src/RegionDropdown.js
+++ b/src/RegionDropdown.js
@@ -113,7 +113,7 @@ export default class RegionDropdown extends PureComponent {
 			name,
 			value,
 			onChange: (e) => onChange(e.target.value, e),
-			onBlur: (e) => onBlur(e),
+			onBlur: (e) => onBlur(e.target.value, e),
 			disabled: isDisabled
 		};
 		if (id) {


### PR DESCRIPTION
This fixes the type mismatch between
- [the type definition in `CountryDropdown.onBlur`](https://github.com/country-regions/react-country-region-selector/blob/master/index.d.ts#L36) and [the component's callback](https://github.com/country-regions/react-country-region-selector/blob/master/src/CountryDropdown.js#L47)
- [the type definition in `RegionDropdown.onBlur`](https://github.com/country-regions/react-country-region-selector/blob/master/index.d.ts#L160) and [the component's callback](https://github.com/country-regions/react-country-region-selector/blob/master/src/RegionDropdown.js#L116)

... and also makes the definitions of `onBlur` and `onChange` consistent for the two components.

I also updated `package-lock.json` after running `npm run build`.