### PR TITLE
fix(ts): correct CountryRegionData typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -258,4 +258,4 @@ export interface RegionDropdownProps<T = Element> {
 
 export class RegionDropdown extends React.Component<RegionDropdownProps> {}
 
-export type CountryRegionData = [string[]];
+export const CountryRegionData: [string[]];


### PR DESCRIPTION
Without this change, TypeScript recognizes `CountryRegionData` is not a typing instead of a value.

Now it's a typed value!