### PR TITLE
change type of showDefaultOption to boolean in RegionDropdownProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -199,7 +199,7 @@ export interface RegionDropdownProps<T = Element> {
    *
    * Default value: true
    */
-  showDefaultOption?: string;
+  showDefaultOption?: boolean;
 
   /**
    * string	The default region option.


### PR DESCRIPTION
Fix the issue: Type of showDefaultOption in RegionDropdownProps interface is string instead of boolean.